### PR TITLE
Fix Add Elephpant button on wishlist

### DIFF
--- a/resources/assets/components/seller/wishlist.vue
+++ b/resources/assets/components/seller/wishlist.vue
@@ -28,7 +28,7 @@
                         <h4>Wishlist</h4>
                     </div>
                     <div class="col-xs-12 col-md-3 add">
-                        <button class="btn btn-success"><router-link to="/profile/elephpant/wishlist/add">Add Elephpant</router-link></button>
+                        <router-link to="/profile/elephpant/wishlist/add" class="btn btn-success" role="button">Add Elephpant</router-link>
                     </div>
                     <hr>
                     <table class="table table-striped">


### PR DESCRIPTION
On the Wishlist page, the `Add Elephpant` button is nonfunctional.  An `<a>` tag with a `href` attribute cannot be a child of `<button>`.  While most browsers support `href` on `<button>` it's not in the spec and thus we'll just render the link as an `<a>` and not a `<button>` and add the appropriate classes (and the `role` attr because that's how Bootstrap rolls).